### PR TITLE
Copy toml files to a temporary directory

### DIFF
--- a/src/pkg.jl
+++ b/src/pkg.jl
@@ -34,3 +34,18 @@ function test(spec::_PackageSpec; kwargs...)
     @info "Testing $spec..."
     return test(testpath; kwargs...)
 end
+
+function copymanifest(oldpath::AbstractString, newpath::AbstractString)
+    open(newpath; write=true) do io
+        for line in eachline(oldpath; keep=true)
+            m = match(r"(path *= *)\"(.*?)\"", line)
+            if m !== nothing && !isabspath(m.captures[2])
+                write(io, m.captures[1])
+                write(io, repr(joinpath(dirname(abspath(oldpath)), m.captures[2])))
+                println(io)
+            else
+                write(io, line)
+            end
+        end
+    end
+end


### PR DESCRIPTION
This is to make it work nicely with running script which may mutate the toml files.  For example, `PkgBenchmark.benchmarkpkg` can check out new revision containing different toml files.